### PR TITLE
Add modal option facility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-examples:=ex1-tiny ex1-smol ex2-tiny ex2-smol ex3-tiny ex3-smol ex4-smol
+examples:=ex1-tiny ex1-smol ex2-tiny ex2-smol ex3-tiny ex3-smol ex4-smol ex5-smol
 all:: unit $(examples)
 
 test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc
@@ -53,6 +53,9 @@ ex3-smol: ex3-smol.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 ex4-smol: ex4-smol.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+ex5-smol: ex5-smol.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 clean:

--- a/ex/README.md
+++ b/ex/README.md
@@ -54,7 +54,7 @@ any values.
 
 As an example, the options `set/one` `set/two` and `set/three` can be combined as:
 ```
-# ex4-smol set/one/two/three
+% ex4-smol set/one/two/three
 set/one
 set/two
 set/three
@@ -63,14 +63,41 @@ set/three
 This example also shows how the saved option data can be used to
 replay previous command line invocations, e.g.
 ```
-# ex4-smol --save saved.opt -aab
+% ex4-smol --save saved.opt -aab
 a=2
 b=1
 # cat saved.opt
 -a -a -b
-# ex4-smol -c $(<saved.opt)
+% ex4-smol -c $(<saved.opt)
 a=2
 b=1
 c=1
 ```
  
+## Example 5 — modal options
+
+Specifying `to::when` and `to::then` in an option allows for
+modal behaviour when parsing the command line arguments.
+
+In `ex5-smol`, the flag "echo" on the command line causes the
+program to emit the following words one per line, while "ohce",
+in turn, causes the following words to be emitted backwards.
+
+The example code also demonstrates the use of `to:error`, an action helper
+that will cause a `to::user_option_error` to be thrown.
+
+Sample run:
+```
+% ex5-smol hello
+ex5-smol: unrecognized keyword
+Usage: ex5-smol [echo [word...] | ohce [word...]] ...
+
+Print words afer 'echo' one per line;
+Print words after 'oche' backwards, one per line.
+% ex5-smol echo how now ohce brown echo cow
+how
+now
+nworb
+cow
+```
+```

--- a/ex/ex5-smol.cc
+++ b/ex/ex5-smol.cc
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <string>
+
+#include <tinyopt/smolopt.h>
+
+const char* usage_str =
+    "[echo [word...] | ohce [word...]] ...\n"
+    "\n"
+    "Print words afer 'echo' one per line;\n"
+    "Print words after 'oche' backwards, one per line.";
+
+void echo(const std::string& s) {
+    std::cout << s << "\n";
+}
+
+void ohce(const std::string& s) {
+    echo(std::string(s.rbegin(), s.rend()));
+}
+
+int main(int argc, char** argv) {
+    try {
+	to::option opts[] = {
+            // 'echo' and 'ohce' are always recognized:
+            { {}, to::flag, "echo", to::then(1) },
+            { {}, to::flag, "ohce", to::then(2) },
+
+            // If mode is zero and we see a word, it's an error.
+	    { to::error("unrecognized keyword"), to::when(0) },
+
+            // If mode is one, echo argument.
+	    { to::action(echo), to::when(1) },
+
+            // If mode is two, echo argument in reverse.
+	    { to::action(ohce), to::when(2) }
+	};
+
+	to::run(opts, argc, argv+1);
+    }
+    catch (to::option_error& e) {
+	to::usage(argv[0], usage_str, e.what());
+	return 1;
+    }
+}

--- a/include/tinyopt/common.h
+++ b/include/tinyopt/common.h
@@ -41,6 +41,11 @@ struct missing_argument: option_error {
         option_error("option misssing argument", arg) {}
 };
 
+struct user_option_error: option_error {
+    user_option_error(const std::string &arg):
+        option_error(arg) {}
+};
+
 // `usage` prints usage information to stdout (no error message)
 // or to stderr (with error message). It extracts the program basename
 // from the provided argv[0] string.

--- a/test/test_run.cc
+++ b/test/test_run.cc
@@ -233,3 +233,22 @@ TEST(run, keyless) {
     EXPECT_EQ("foo"s, kl_first);
     EXPECT_EQ(3, kl_second);
 }
+
+TEST(run, modal) {
+    int a0 = 0, a1 = 0, a2 = 0;
+    to::option opts[] = {
+        {to::increment(a0), "-a", to::flag, to::when(0)},
+        {to::increment(a1), "-a", to::flag, to::when(1)},
+        {to::increment(a2), "-a", to::flag, to::when(2)},
+        {{}, "one", to::flag, to::then(1)},
+        {{}, "two", to::flag, to::then(2)}
+    };
+
+    mockargs M("-a\0one\0-a\0two\0-a\0-a\0one\0-a\0-a\0");
+    auto r = to::run(opts, M.argc, M.argv);
+    EXPECT_TRUE(r);
+
+    EXPECT_EQ(1, a0);
+    EXPECT_EQ(3, a1);
+    EXPECT_EQ(2, a2);
+}

--- a/test/test_sink.cc
+++ b/test/test_sink.cc
@@ -5,6 +5,11 @@
 
 #include <tinyopt/smolopt.h>
 
+TEST(sink, empty) {
+    to::sink s;
+    EXPECT_TRUE(s("foo"));
+}
+
 TEST(sink, refctor) {
     int a;
     to::sink sa(a);


### PR DESCRIPTION
* Extend options with filters and mode setters to enable selective application of options during parsing.
* Fix bug in to::action that caused it trip over functions which took reference arguments.
* Add new to::sink helper `to::error` that throws an exception on match.
* Update tests for new functionality.
* Add example for demonstrating the model facility.
* Update top level README.