### PR TITLE
Remove special handling for '--' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,18 @@ Option behaviour can be modified by supplying `enum option_flag` values:
 * `single` — This option will be checked at most once, and then ignored for the remainder of option processing.
 * `mandatory` — Throw an exception if this option does not appear in the command line arguments.
 * `exit` — On successful parsing of this option, stop any further option processing and return `nothing` from `run()`.
+* `stop` — On successful parsing of this option, stop any further option processing but return saved options as normal from `run()`.
 
 These enum values are all powers of two and can be combined via bitwise or `|`.
+
+When to use `exit`, and when to use `stop`? `exit` is intended to describe
+the situation where the program should not proceed further with normal
+processing; a standard use case for `exit` is for `--help` options, which
+should cause the program to exit after printing help text. `stop`, on the
+other hand, is used for options that indicate that no further special
+argument processing should be performed; this corresponds to the common
+convention of `--` on the command line indicating that all remaining
+arguments should be interpreted as command line options.
 
 #### Specifying an option
 
@@ -534,7 +544,6 @@ In the following `Options` is any iterable collection of `option` values.
    Parse the items in `argv` against the options provided in the first argument.
    Starting at the beginning of the `argv` list, options with keys are checked first,
    in the order they appear in `options`, followed by options without keys.
-   An item `--` in `argv` stops any further processing of options.
 
    Successfully parsed options are removed from the `argv` list in-place, and
    `argc` is adjusted accordingly.

--- a/ex/README.md
+++ b/ex/README.md
@@ -36,6 +36,8 @@ manually. When using `to::run`, however, the argument list will
 be modified in place, removing matched options.
 
 The two approaches are exemplified in `ex3-parse` and `ex3-run`.
+Note the use of `to::stop` in `ex3-run` for implementing the
+option `--`.
 
 ## Example 4 — compact options
 

--- a/ex/ex3-parse.cc
+++ b/ex/ex3-parse.cc
@@ -8,7 +8,8 @@ const char* usage_str =
     "[OPTION]... [ARGUMENT]...\n"
     "\n"
     "  -a, --apple    Print 'apple' but otherwise ignore.\n"
-    "  -h, --help     Display usage information and exit\n"
+    "  --             Stop further argument processing.\n"
+    "  -h, --help     Display usage information and exit.\n"
     "\n"
     "Throw away --apple options and report remaining arguments.\n";
 
@@ -17,11 +18,14 @@ int main(int argc, char** argv) {
         std::vector<std::string> remaining;
         auto print_apple = [] { std::cout << "apple!\n"; };
         bool help = false;
+        bool stop = false;
 
-        for (auto arg = argv+1; *arg; ) {
+        char** arg = argv+1;
+        while (*arg && !help && !stop) {
             bool match =
                 help        << to::parse(arg, "-h", "--help") ||
-                print_apple << to::parse(arg, "-a", "--apple");
+                print_apple << to::parse(arg, "-a", "--apple") ||
+                stop        << to::parse(arg, "--");
 
             if (!match) remaining.push_back(*arg++);
         }
@@ -30,6 +34,9 @@ int main(int argc, char** argv) {
             to::usage(argv[0], usage_str);
             return 0;
         }
+
+        // Grab any remaining unprocessed arguments, too.
+        while (*arg) remaining.push_back(*arg++);
 
         std::cout << "remaining arguments:";
         for (auto& a: remaining) std::cout << ' ' << a;

--- a/ex/ex3-run.cc
+++ b/ex/ex3-run.cc
@@ -8,7 +8,8 @@ const char* usage_str =
     "[OPTION]... [ARGUMENT]...\n"
     "\n"
     "  -a, --apple    Print 'apple' but otherwise ignore.\n"
-    "  -h, --help     Display usage information and exit\n"
+    "  --             Stop further argument processing.\n"
+    "  -h, --help     Display usage information and exit.\n"
     "\n"
     "Throw away --apple options and report remaining arguments.\n";
 
@@ -19,7 +20,8 @@ int main(int argc, char** argv) {
 
         to::option opts[] = {
             { to::action(print_apple), to::flag, "-a", "--apple" },
-            { to::action(help), to::flag, to::exit, "-h", "--help" }
+            { to::action(help), to::flag, to::exit, "-h", "--help" },
+            { {}, to::flag, to::stop, "--" }
         };
 
         if (!to::run(opts, argc, argv+1)) return 0;

--- a/include/tinyopt/tinyopt.h
+++ b/include/tinyopt/tinyopt.h
@@ -722,7 +722,8 @@ enum option_flag {
     ephemeral = 2,  // Option is not saved in returned results.
     single = 4,     // Option is parsed at most once.
     mandatory = 8,  // Option must be present in argument list.
-    exit = 16,      // Option stops further argument processing.
+    exit = 16,      // Option stops further argument processing, return `nothing` from run().
+    stop = 32,      // Option stops further argument processing, return saved options.
 };
 
 struct option {
@@ -736,6 +737,7 @@ struct option {
     bool is_single = false;
     bool is_mandatory = false;
     bool is_exit = false;
+    bool is_stop = false;
 
     template <typename... Rest>
     option(sink s, Rest&&... rest): s(std::move(s)) {
@@ -784,6 +786,7 @@ private:
         is_single    |= f & single;
         is_mandatory |= f & mandatory;
         is_exit      |= f & exit;
+        is_stop      |= f & stop;
         init_(std::forward<Rest>(rest)...);
     }
 
@@ -981,9 +984,10 @@ namespace impl {
     inline maybe<saved_options> run(std::vector<impl::counted_option>& opts, int& argc, char** argv) {
         saved_options collate;
         bool exit = false;
+        bool stop = false;
         state st{argc, argv};
         int mode = 0;
-        while (st && !exit) {
+        while (st && !exit && !stop) {
             // Try options with a key first.
             for (auto& o: opts) {
                 if (o.keys.empty()) continue;
@@ -997,6 +1001,7 @@ namespace impl {
                     }
                     o.set_mode(mode);
                     exit = o.is_exit;
+                    stop = o.is_stop;
                     goto next;
                 }
             }


### PR DESCRIPTION
* Add `to::stop` flag for options used to emulate the commonly implemented behaviour for '--', which stops further option processing.