### PR TITLE
Fix missing clang++ problem in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-20.04 ]
-                cxx: [ g++-9, g++-10, clang++-9, clang++-11 ]
+                cxx: [ g++-9, g++-10, clang++-10, clang++-11 ]
                 include :
                     - os: "macos-latest"
                       cxx: "clang++"

--- a/ex/README.md
+++ b/ex/README.md
@@ -71,7 +71,7 @@ a=2
 b=1
 c=1
 ```
- 
+
 ## Example 5 — modal options
 
 Specifying `to::when` and `to::then` in an option allows for
@@ -97,5 +97,4 @@ how
 now
 nworb
 cow
-```
 ```


### PR DESCRIPTION
* Change test env to use clang++10 instead of clang++9.
* Includes minor formatting fixes in ex/README.md.