### PR TITLE
Add support for std::optional reference sinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,14 @@ jobs:
             matrix:
                 os: [ ubuntu-20.04 ]
                 cxx: [ g++-9, g++-10, clang++-10, clang++-11 ]
+                cxxstd: [ c++14, c++17 ]
                 include :
                     - os: "macos-latest"
                       cxx: "clang++"
+                      cxxstd: "c++14"
         env:
             CXX: ${{ matrix.cxx }}
+            CXXSTD: ${{ matrix.cxxstd }}
         steps:
             - uses: actions/checkout@v1
               with:
@@ -25,7 +28,7 @@ jobs:
                   ${CXX} --version
                   mkdir build
                   cd build
-                  make -j4 -f ../Makefile
+                  make -j4 CXXSTD=${CXXSTD} -f ../Makefile
             - name: Run unit tests.
               run: build/unit
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ gtest-src:=$(gtest-top)/src/gtest-all.cc
 vpath %.cc $(top)test
 vpath %.cc $(top)ex
 
+CXXSTD?=c++14
 OPTFLAGS?=-O2 -fsanitize=address -march=native
-CXXFLAGS+=$(OPTFLAGS) -MMD -MP -std=c++14 -pedantic -Wall -Wextra -g -pthread
+CXXFLAGS+=$(OPTFLAGS) -MMD -MP -std=$(CXXSTD) -pedantic -Wall -Wextra -g -pthread
 CPPFLAGS+=-isystem $(gtest-inc) -I $(top)include
 
 depends:=$(patsubst %.cc, %.d, $(all-src)) gtest.d

--- a/include/tinyopt/tinyopt.h
+++ b/include/tinyopt/tinyopt.h
@@ -12,6 +12,10 @@
 #include <type_traits>
 #include <vector>
 
+#if __cplusplus>=201703
+#include <optional>
+#endif
+
 #define TINYOPT_VERSION "1.0"
 #define TINYOPT_VERSION_MAJOR 1
 #define TINYOPT_VERSION_MINOR 0
@@ -259,8 +263,8 @@ struct default_parser {
         V v;
         std::istringstream stream(text);
         if (!(stream >> v)) return nothing;
-	if (!stream.eof()) stream >> std::ws;
-	return stream.eof()? maybe<V>(v): nothing;
+        if (!stream.eof()) stream >> std::ws;
+        return stream.eof()? maybe<V>(v): nothing;
     }
 };
 
@@ -576,6 +580,13 @@ struct sink {
 
     template <typename V>
     sink(V& var): sink(var, default_parser<V>{}) {}
+
+#if __cplusplus>=201703
+    template <typename V>
+    sink(std::optional<V>& var): sink(var, default_parser<V>{}) {}
+#endif
+    template <typename V>
+    sink(maybe<V>& var): sink(var, default_parser<V>{}) {}
 
     template <typename V, typename P>
     sink(V& var, P parser):

--- a/test/test_sink.cc
+++ b/test/test_sink.cc
@@ -1,6 +1,10 @@
 #include <cstdlib>
 #include <string>
 
+#if __cplusplus>=201703
+#include <optional>
+#endif
+
 #include <gtest/gtest.h>
 #include <tinyopt/tinyopt.h>
 
@@ -22,7 +26,33 @@ TEST(sink, refctor) {
     to::sink sb(a, [](const char*) { return to::just(17); });
     EXPECT_TRUE(sb("foo"));
     EXPECT_EQ(17, a);
+
+    to::maybe<int> ma;
+    to::sink sma(ma);
+
+    ASSERT_FALSE(ma);
+    EXPECT_FALSE(sma("foo"));
+    EXPECT_FALSE(ma);
+
+    EXPECT_TRUE(sma("312"));
+    EXPECT_TRUE(ma);
+    EXPECT_EQ(*ma, 312);
 }
+
+#if __cplusplus>=201703
+TEST(sink, optionalrefctor) {
+    std::optional<int> oa;
+    to::sink soa(oa);
+
+    ASSERT_FALSE(oa);
+    EXPECT_FALSE(soa("foo"));
+    EXPECT_FALSE(oa);
+
+    EXPECT_TRUE(soa("312"));
+    EXPECT_TRUE(oa);
+    EXPECT_EQ(*oa, 312);
+}
+#endif
 
 TEST(sink, action_explicit) {
     char x;


### PR DESCRIPTION
* Use `default_parser<V>` in default variable reference sinks if the reference is to `to::maybe<V>` or `std::optional<V>`.
* Add tests for same.
* Tab -> spaces.