### PR TITLE
Support for optional arguments with to::lax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
                 os: [ ubuntu-22.04 ]
                 cxx: [ g++-10, g++-13, clang++-13, clang++-15 ]
                 cxxstd: [ c++14, c++17, c++20 ]
+                exclude: # exclusions to work around https://github.com/actions/runner-images/issues/8659
+                    - os: "ubuntu-22.04"
+                      cxx: clang++-15
+                      cxxstd: c++20
+                    - os: "ubuntu-22.04"
+                      cxx: clang++-13
+                      cxxstd: c++20
                 include:
                     - os: "macos-latest"
                       cxx: "clang++"

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 examples:=ex1-parse ex1-run ex2-parse ex2-run ex3-parse ex3-run ex4-run ex5-run ex6-run
 all:: unit $(examples)
 
-# test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
-test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
+test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
 
 all-src:=$(test-src) $(patsubst %, %.cc, $(examples))
 all-obj:=$(patsubst %.cc, %.o, $(all-src))

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ ex5-run: ex5-run.o
 ex6-run: ex6-run.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
+ex7-run: ex7-run.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
 clean:
 	rm -f $(all-obj)
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@
 
 top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-examples:=ex1-parse ex1-run ex2-parse ex2-run ex3-parse ex3-run ex4-run ex5-run
+examples:=ex1-parse ex1-run ex2-parse ex2-run ex3-parse ex3-run ex4-run ex5-run ex6-run
 all:: unit $(examples)
 
-test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
+# test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
+test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc
 
 all-src:=$(test-src) $(patsubst %, %.cc, $(examples))
 all-obj:=$(patsubst %.cc, %.o, $(all-src))
@@ -56,6 +57,9 @@ ex4-run: ex4-run.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 ex5-run: ex5-run.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+ex6-run: ex6-run.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 top:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 
-examples:=ex1-parse ex1-run ex2-parse ex2-run ex3-parse ex3-run ex4-run ex5-run ex6-run
+examples:=ex1-parse ex1-run ex2-parse ex2-run ex3-parse ex3-run ex4-run ex5-run ex6-run ex7-run
 all:: unit $(examples)
 
 test-src:=unit.cc test_sink.cc test_maybe.cc test_option.cc test_state.cc test_parse.cc test_parsers.cc test_saved_options.cc test_run.cc test_version.cc

--- a/ex/ex1-parse.cc
+++ b/ex/ex1-parse.cc
@@ -5,9 +5,11 @@
 const char* usage_str =
     "[OPTION]...\n"
     "\n"
-    "  -n, --number=N       Specify N\n"
-    "  -f, --function=FUNC  Perform FUNC, which is one of: one, two\n"
-    "  -h, --help           Display usage information and exit\n";
+    "  -n, --number=N       specify number of times to perform function\n"
+    "  -f, --function=FUNC  specify function, which is one of: one, two;\n"
+    "                       this option is mandatory\n"
+    "\n"
+    "  -h, --help           display usage information and exit\n";
 
 int main(int, char** argv) {
     try {

--- a/ex/ex1-run.cc
+++ b/ex/ex1-run.cc
@@ -5,9 +5,11 @@
 const char* usage_str =
     "[OPTION]...\n"
     "\n"
-    "  -n, --number=N       Specify N\n"
-    "  -f, --function=FUNC  Perform FUNC, which is one of: one, two\n"
-    "  -h, --help           Display usage information and exit\n";
+    "  -n, --number=N       specify number of times to perform function\n"
+    "  -f, --function=FUNC  specify function, which is one of: one, two;\n"
+    "                       this option is mandatory\n"
+    "\n"
+    "  -h, --help           display usage information and exit\n";
 
 int main(int argc, char** argv) {
     try {
@@ -27,7 +29,7 @@ int main(int argc, char** argv) {
 
         if (!to::run(opts, argc, argv+1)) return 0;
 
-        if (argv[1]) throw to::option_error("unrecogonized argument", argv[1]);
+        if (argv[1]) throw to::option_error("unrecognized argument", argv[1]);
         if (n<1) throw to::option_error("N must be at least 1");
 
         // Do things with arguments:

--- a/ex/ex2-parse.cc
+++ b/ex/ex2-parse.cc
@@ -7,8 +7,8 @@
 const char* usage_str =
     "[OPTION]...\n"
     "\n"
-    "  --sum=N1,..,Nk   Sum the integers N1 through Nk.\n"
-    "  -h, --help       Display usage information and exit\n";
+    "  --sum=N1,..,Nk   sum the integers N1 through Nk\n"
+    "  -h, --help       display usage information and exit\n";
 
 int main(int, char** argv) {
     try {

--- a/ex/ex2-run.cc
+++ b/ex/ex2-run.cc
@@ -7,8 +7,8 @@
 const char* usage_str =
     "[OPTION]...\n"
     "\n"
-    "  --sum=N1,..,Nk   Sum the integers N1 through Nk.\n"
-    "  -h, --help       Display usage information and exit\n";
+    "  --sum=N1,..,Nk   sum the integers N1 through Nk\n"
+    "  -h, --help       display usage information and exit\n";
 
 int main(int argc, char** argv) {
     try {

--- a/ex/ex3-parse.cc
+++ b/ex/ex3-parse.cc
@@ -7,11 +7,12 @@
 const char* usage_str =
     "[OPTION]... [ARGUMENT]...\n"
     "\n"
-    "  -a, --apple    Print 'apple' but otherwise ignore.\n"
-    "  --             Stop further argument processing.\n"
-    "  -h, --help     Display usage information and exit.\n"
+    "  -a, --apple    print 'apple'\n"
     "\n"
-    "Throw away --apple options and report remaining arguments.\n";
+    "  --             stop further argument processing\n"
+    "  -h, --help     display usage information and exit\n"
+    "\n"
+    "Disregarding --apple options, report remaining arguments.\n";
 
 int main(int, char** argv) {
     try {

--- a/ex/ex3-run.cc
+++ b/ex/ex3-run.cc
@@ -7,11 +7,12 @@
 const char* usage_str =
     "[OPTION]... [ARGUMENT]...\n"
     "\n"
-    "  -a, --apple    Print 'apple' but otherwise ignore.\n"
-    "  --             Stop further argument processing.\n"
-    "  -h, --help     Display usage information and exit.\n"
+    "  -a, --apple    print 'apple'\n"
     "\n"
-    "Throw away --apple options and report remaining arguments.\n";
+    "  --             stop further argument processing\n"
+    "  -h, --help     display usage information and exit\n"
+    "\n"
+    "Disregarding --apple options, report remaining arguments.\n";
 
 int main(int argc, char** argv) {
     try {

--- a/ex/ex6-run.cc
+++ b/ex/ex6-run.cc
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <string>
+
+#include <tinyopt/tinyopt.h>
+
+const char* usage_str =
+    "[-n [ fish | cake ] | -n INT | -n] ...\n"
+    "\n"
+    "Parse and display -n options with either a keyword argument,\n"
+    "an integer argument, or without arguments.\n";
+
+void print_kw(const char* kw) {
+    std::cout << "keyword argument: " << kw << "\n";
+}
+
+void print_int(int n) {
+    std::cout << "integer argument: " << n << "\n";
+}
+
+void print_flag() {
+    std::cout << "no argument\n";
+}
+
+int main(int argc, char** argv) {
+    try {
+        std::pair<const char*, const char*> kw_tbl[] = {
+            { "fish", "FISH" }, { "cake", "CAKE" }
+        };
+
+        auto help = [argv0 = argv[0]] { to::usage(argv0, usage_str); };
+
+        to::option opts[] = {
+            { to::action(help), "-h", "--help" },
+            { to::action(print_kw, to::keywords(kw_tbl)), "-n", to::lax },
+            { to::action(print_int, to::default_parser<int>{}), "-n", to::lax },
+            { to::action(print_flag), "-n", to::flag },
+        };
+
+        to::run(opts, argc, argv+1);
+    }
+    catch (to::option_error& e) {
+        to::usage_error(argv[0], usage_str, e.what());
+        return 1;
+    }
+}

--- a/ex/ex6-run.cc
+++ b/ex/ex6-run.cc
@@ -4,10 +4,12 @@
 #include <tinyopt/tinyopt.h>
 
 const char* usage_str =
-    "[-n [ fish | cake ] | -n INT | -n] ...\n"
+    "[OPTIONS]...\n"
     "\n"
-    "Parse and display -n options with either a keyword argument,\n"
-    "an integer argument, or without arguments.\n";
+    "  -n fish | cake     print a message indicating a keyword argument\n"
+    "  -n INT             print a message indicating aninteger argument\n"
+    "  -n                 print a message indicating no argument\n"
+    "  -h, --help         display usage information and exit\n";
 
 void print_kw(const char* kw) {
     std::cout << "keyword argument: " << kw << "\n";
@@ -37,6 +39,7 @@ int main(int argc, char** argv) {
         };
 
         to::run(opts, argc, argv+1);
+        if (argv[1]) throw to::option_error("unrecognized argument", argv[1]);
     }
     catch (to::option_error& e) {
         to::usage_error(argv[0], usage_str, e.what());

--- a/ex/ex7-run.cc
+++ b/ex/ex7-run.cc
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <iterator>
+#include <vector>
+
+#include <tinyopt/tinyopt.h>
+
+const char* usage_str =
+    "[-n [ INT [ INT [ INT ] ] ] | -a | -b ] ...\n"
+    "\n"
+    "Collect vectors of up to 3 integers as multiple arguments to the -n option.\n"
+    "Count occurances of flags -a and -b.\n";
+
+int main(int argc, char** argv) {
+    try {
+        auto help = [argv0 = argv[0]] { to::usage(argv0, usage_str); };
+
+        std::vector<std::vector<int>> nss;
+        auto new_ns = [&]() { nss.push_back({}); return true; };
+        auto push_ns = [&](int n) { nss.back().push_back(n); return true; };
+
+        int a = 0, b = 0;
+
+#if 0
+        to::option opts[] = {
+            { to::action(help), "-h", "--help", to::exit },
+            { to::increment(a), to::then(0), "-a", to::flag },
+            { to::increment(b), to::then(0), "-b", to::flag },
+            { to::action(new_ns), to::then(1), "-n", to::flag },
+            { to::action(push_ns), to::when(1) }
+        };
+#endif
+        auto gt0 = [](int m) { return m>0; };
+        auto decrement = [](int m) { return m-1; };
+
+        to::option opts[] = {
+            { to::action(help), "-h", "--help", to::exit },
+            { to::increment(a), to::then(0), "-a", to::flag },
+            { to::increment(b), to::then(0), "-b", to::flag },
+            { to::action(new_ns), to::then(3), "-n", to::flag },
+            { to::action(push_ns), to::when(gt0), to::then(decrement)}
+        };
+
+        if (!to::run(opts, argc, argv+1)) return 0;
+        if (argv[1]) throw to::option_error("unrecogonized argument", argv[1]);
+
+        std::cout << "a count: " << a << "\nb count: " << b << "\n";
+        std::cout << "ns:\n";
+        for (auto& ns: nss) {
+            std::cout << "{ ";
+            std::ostream_iterator<int> os(std::cout, " ");
+            for (int n: ns) *os = n;
+            std::cout << "}\n";
+        }
+    }
+    catch (to::option_error& e) {
+        to::usage_error(argv[0], usage_str, e.what());
+        return 1;
+    }
+}

--- a/ex/ex7-run.cc
+++ b/ex/ex7-run.cc
@@ -5,46 +5,34 @@
 #include <tinyopt/tinyopt.h>
 
 const char* usage_str =
-    "[-n [ INT [ INT [ INT ] ] ] | -a | -b ] ...\n"
+    "[OPTION] ...\n"
     "\n"
-    "Collect vectors of up to 3 integers as multiple arguments to the -n option.\n"
-    "Count occurances of flags -a and -b.\n";
+    "  -n [ INT [ INT [ INT ] ] ]  collect a vector of up to 3 integers\n"
+    "  -h, --help                  display usage information and exit\n"
+    "\n"
+    "Collect and display vectors of up to 3 integers as multiple arguments to the -n option.\n";
 
 int main(int argc, char** argv) {
     try {
         auto help = [argv0 = argv[0]] { to::usage(argv0, usage_str); };
 
         std::vector<std::vector<int>> nss;
+
         auto new_ns = [&]() { nss.push_back({}); return true; };
         auto push_ns = [&](int n) { nss.back().push_back(n); return true; };
 
-        int a = 0, b = 0;
-
-#if 0
-        to::option opts[] = {
-            { to::action(help), "-h", "--help", to::exit },
-            { to::increment(a), to::then(0), "-a", to::flag },
-            { to::increment(b), to::then(0), "-b", to::flag },
-            { to::action(new_ns), to::then(1), "-n", to::flag },
-            { to::action(push_ns), to::when(1) }
-        };
-#endif
         auto gt0 = [](int m) { return m>0; };
         auto decrement = [](int m) { return m-1; };
 
         to::option opts[] = {
-            { to::action(help), "-h", "--help", to::exit },
-            { to::increment(a), to::then(0), "-a", to::flag },
-            { to::increment(b), to::then(0), "-b", to::flag },
+            { to::action(help), "-h", "--help", to::flag, to::exit },
             { to::action(new_ns), to::then(3), "-n", to::flag },
             { to::action(push_ns), to::when(gt0), to::then(decrement)}
         };
 
         if (!to::run(opts, argc, argv+1)) return 0;
-        if (argv[1]) throw to::option_error("unrecogonized argument", argv[1]);
+        if (argv[1]) throw to::option_error("unrecognized argument", argv[1]);
 
-        std::cout << "a count: " << a << "\nb count: " << b << "\n";
-        std::cout << "ns:\n";
         for (auto& ns: nss) {
             std::cout << "{ ";
             std::ostream_iterator<int> os(std::cout, " ");

--- a/include/tinyopt/tinyopt.h
+++ b/include/tinyopt/tinyopt.h
@@ -487,7 +487,7 @@ struct state {
     maybe<match_result> match_option(const key& k) {
         if (k.style==key::compact) {
             if (auto m = match_compact_key(k.label.c_str())) {
-                if (*argv[optoff+*m])
+                if ((*argv)[optoff+*m])
                     return match_result{*argv+optoff+*m, 1, 0};
                 else
                     return match_result{argv[1], 2, 0};
@@ -511,7 +511,7 @@ struct state {
     maybe<match_result> match_flag(const key& k) {
         if (k.style==key::compact) {
             if (auto m = match_compact_key(k.label.c_str())) {
-                if (*argv[optoff+*m]) 
+                if ((*argv)[optoff+*m]) 
                     return match_result{nullptr, 0, *m};
                 else
                     return match_result{nullptr, 1, 0};

--- a/test/test_state.cc
+++ b/test/test_state.cc
@@ -14,8 +14,12 @@ TEST(state, shift) {
     mockargs M(argstr);
 
     std::vector<char*> v0 = M.args;
-
     to::state s(M.argc, M.argv);
+
+    s.shift(0);
+    EXPECT_EQ(7, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[0], M.argv[0]);
 
     s.shift();
     EXPECT_EQ(6, M.argc);
@@ -37,6 +41,42 @@ TEST(state, shift) {
     EXPECT_EQ(v0[4], s.argv[0]);
 }
 
+TEST(state, consume) {
+    const char* argstr = "zero\0one\0two\0three\0four\0five\0six\0";
+    mockargs M(argstr);
+
+    std::vector<char*> v0 = M.args;
+    to::state s(M.argc, M.argv);
+
+    typedef to::state::match_result MR;
+
+
+    s.consume(MR{nullptr, 0, 0});
+    EXPECT_EQ(7, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[0], M.argv[0]+s.optoff);
+
+    s.consume(MR{nullptr, 0, 2});
+    EXPECT_EQ(7, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[0]+2, M.argv[0]+s.optoff);
+
+    s.consume(MR{nullptr, 2, 0});
+    EXPECT_EQ(5, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[2], M.argv[0]+s.optoff);
+
+    s.consume(MR{nullptr, 0, 2});
+    EXPECT_EQ(5, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[2]+2, M.argv[0]+s.optoff);
+
+    s.consume(MR{nullptr, 1, 1});
+    EXPECT_EQ(4, M.argc);
+    EXPECT_EQ(0, M.argv[M.argc]);
+    EXPECT_EQ(v0[3]+1, M.argv[0]+s.optoff);
+}
+
 TEST(state, match_long) {
     to::key k("key", to::key::longfmt);
 
@@ -44,9 +84,13 @@ TEST(state, match_long) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("value"s, *arg);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("value"s, mmr->argument);
+        EXPECT_EQ(2u, mmr->shift);
+        EXPECT_EQ(0u, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 
@@ -54,8 +98,13 @@ TEST(state, match_long) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(true, arg);
+        auto mmr = s.match_flag(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ(nullptr, mmr->argument);
+        EXPECT_EQ(1u, mmr->shift);
+        EXPECT_EQ(0u, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("value"s, M.argv[0]);
     }
 
@@ -63,18 +112,21 @@ TEST(state, match_long) {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(false, arg);
-        EXPECT_EQ("key=value"s, M.argv[0]);
+        auto mmr = s.match_flag(k);
+        ASSERT_FALSE(mmr);
     }
 
     {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("value"s, *arg);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("value"s, mmr->argument);
+        EXPECT_EQ(1u, mmr->shift);
+        EXPECT_EQ(0u, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 
@@ -82,9 +134,8 @@ TEST(state, match_long) {
         mockargs M("keyvalue\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        EXPECT_FALSE(arg);
-        EXPECT_EQ("keyvalue"s, M.argv[0]);
+        auto mmr = s.match_option(k);
+        ASSERT_FALSE(mmr);
     }
 }
 
@@ -95,9 +146,13 @@ TEST(state, match_short) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("value"s, *arg);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("value"s, mmr->argument);
+        EXPECT_EQ(2u, mmr->shift);
+        EXPECT_EQ(0u, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 
@@ -105,8 +160,13 @@ TEST(state, match_short) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(true, arg);
+        auto mmr = s.match_flag(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ(nullptr, mmr->argument);
+        EXPECT_EQ(1u, mmr->shift);
+        EXPECT_EQ(0u, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("value"s, M.argv[0]);
     }
 
@@ -114,27 +174,24 @@ TEST(state, match_short) {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        EXPECT_FALSE(arg);
-        EXPECT_EQ("key=value"s, M.argv[0]);
+        auto mmr = s.match_option(k);
+        ASSERT_FALSE(mmr);
     }
 
     {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(false, arg);
-        EXPECT_EQ("key=value"s, M.argv[0]);
+        auto mmr = s.match_option(k);
+        ASSERT_FALSE(mmr);
     }
 
     {
         mockargs M("keyvalue\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        EXPECT_FALSE(arg);
-        EXPECT_EQ("keyvalue"s, M.argv[0]);
+        auto mmr = s.match_option(k);
+        ASSERT_FALSE(mmr);
     }
 }
 
@@ -145,9 +202,13 @@ TEST(state, match_compact) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("value"s, *arg);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("value"s, mmr->argument);
+        EXPECT_EQ(2, mmr->shift);
+        EXPECT_EQ(0, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 
@@ -155,8 +216,13 @@ TEST(state, match_compact) {
         mockargs M("key\0value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(true, arg);
+        auto mmr = s.match_flag(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ(nullptr, mmr->argument);
+        EXPECT_EQ(1, mmr->shift);
+        EXPECT_EQ(0, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("value"s, M.argv[0]);
     }
 
@@ -164,9 +230,13 @@ TEST(state, match_compact) {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("=value"s, *arg);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("=value"s, mmr->argument);
+        EXPECT_EQ(1, mmr->shift);
+        EXPECT_EQ(0, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 
@@ -174,19 +244,29 @@ TEST(state, match_compact) {
         mockargs M("key=value\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_flag(k);
-        EXPECT_EQ(true, arg);
+        auto mmr = s.match_flag(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ(nullptr, mmr->argument);
+        EXPECT_EQ(0, mmr->shift);
+        EXPECT_EQ(3, mmr->offset);
+
+        s.consume(*mmr);
         EXPECT_EQ("key=value"s, M.argv[0]);
+        EXPECT_EQ("=value"s, M.argv[0]+s.optoff);
     }
 
     {
         mockargs M("keyvalue\0rest\0");
         to::state s(M.argc, M.argv);
 
-        auto arg = s.match_option(k);
-        ASSERT_TRUE(arg);
-        EXPECT_EQ("value"s, *arg);
-        EXPECT_EQ("rest"s, M.argv[0]);
+        auto mmr = s.match_option(k);
+        ASSERT_TRUE(mmr);
+        EXPECT_EQ("value"s, mmr->argument);
+        EXPECT_EQ(1, mmr->shift);
+        EXPECT_EQ(0, mmr->offset);
+
+        s.consume(*mmr);
+        EXPECT_EQ("rest"s, M.argv[0]+s.optoff);
     }
 }
 
@@ -200,11 +280,22 @@ TEST(state, match_multi_compact) {
         mockargs M("key/one/three/two\0key/four\0rest\0");
         to::state s(M.argc, M.argv);
 
-        EXPECT_TRUE(s.match_flag(k1));
-        EXPECT_FALSE(s.match_flag(k2));
-        EXPECT_TRUE(s.match_flag(k3));
-        EXPECT_TRUE(s.match_flag(k2));
-        EXPECT_TRUE(s.match_flag(k4));
+        to::maybe<to::state::match_result> mmr;
+
+        ASSERT_TRUE(mmr = s.match_flag(k1));
+        s.consume(*mmr);
+
+        ASSERT_FALSE(mmr = s.match_flag(k2));
+
+        ASSERT_TRUE(mmr = s.match_flag(k3));
+        s.consume(*mmr);
+
+        ASSERT_TRUE(mmr = s.match_flag(k2));
+        s.consume(*mmr);
+
+        ASSERT_TRUE(mmr = s.match_flag(k4));
+        s.consume(*mmr);
+
         EXPECT_EQ("rest"s, M.argv[0]);
     }
 }


### PR DESCRIPTION
* Add `to::lax` flag for options that allows a failure to parse to be interpreted as a failure to match rather than as an exception-throwing error; update unit tests to suit.
* Update documentation to describe `to::lax`.
* Add examples and associated documentation for new facility and for the use of modals to support a form of multiple-operands for an option.
* Edit exisiting examples for consistency.
* Minor documentation edits.

Implements #18.